### PR TITLE
Remove duplicate deploy_distribution_s3_credentials_endpoint from cum…

### DIFF
--- a/cumulus-tf/main.tf
+++ b/cumulus-tf/main.tf
@@ -70,7 +70,6 @@ module "cumulus" {
 
   archive_api_users = var.api_users
 
-  deploy_distribution_s3_credentials_endpoint = var.deploy_distribution_s3_credentials_endpoint
   distribution_url = var.distribution_url
 
   archive_api_port            = var.archive_api_port


### PR DESCRIPTION
Remove duplicate key  `deploy_distribution_s3_credentials_endpoint` from cumulus-tf/main.tf