### PR TITLE
[Pending next release] CUMULUS-1755: Make TEA secret required

### DIFF
--- a/cumulus-tf/main.tf
+++ b/cumulus-tf/main.tf
@@ -71,6 +71,7 @@ module "cumulus" {
   archive_api_users = var.api_users
 
   distribution_url = var.distribution_url
+  thin_egress_jwt_secret_name = var.thin_egress_jwt_secret_name
 
   archive_api_port            = var.archive_api_port
   private_archive_api_gateway = var.private_archive_api_gateway

--- a/cumulus-tf/terraform.tfvars.example
+++ b/cumulus-tf/terraform.tfvars.example
@@ -46,6 +46,9 @@ api_users = [
 
 token_secret = "asdf"
 
+# Name of secret in AWS secrets manager containing SSH keys for signing JWTs
+thin_egress_jwt_secret_name = "secret_name"
+
 data_persistence_remote_state_config = {
   bucket = "PREFIX-tf-state"
   key    = "PREFIX/data-persistence/terraform.tfstate"

--- a/cumulus-tf/variables.tf
+++ b/cumulus-tf/variables.tf
@@ -96,6 +96,11 @@ variable "system_bucket" {
   type = string
 }
 
+variable "thin_egress_jwt_secret_name" {
+  type        = string
+  description = "Name of AWS secret where keys for the Thin Egress App JWT encode/decode are stored"
+}
+
 variable "token_secret" {
   type = string
 }


### PR DESCRIPTION
Once the next version of Cumulus using TEA build 61 is released, this PR should be updated to use those module versions and is ready for review