### PR TITLE
rename "saml_launchpad_metadata_path" to "saml_launchpad_metadata_url"

### DIFF
--- a/cumulus-tf/main.tf
+++ b/cumulus-tf/main.tf
@@ -52,7 +52,7 @@ module "cumulus" {
   saml_entity_id                  = var.saml_entity_id
   saml_assertion_consumer_service = var.saml_assertion_consumer_service
   saml_idp_login                  = var.saml_idp_login
-  saml_launchpad_metadata_path    = var.saml_launchpad_metadata_path
+  saml_launchpad_metadata_url     = var.saml_launchpad_metadata_url
 
   permissions_boundary_arn = var.permissions_boundary_arn
 

--- a/cumulus-tf/terraform.tfvars.example
+++ b/cumulus-tf/terraform.tfvars.example
@@ -79,7 +79,7 @@ oauth_provider = "earthdata"
 # saml_entity_id                  = "Configured SAML entity-id"
 # saml_assertion_consumer_service = "<Cumulus API endpoint>/saml/auth, e.g. https://example.com/saml/auth"
 # saml_idp_login                  = "nasa's saml2sso endpoint, e.g. https://example.gov/affwebservices/public/saml2sso"
-# saml_launchpad_metadata_path    = "s3 url to identity provider public metadata xml file, e.g. s3://system_bucket/PREFIX/launchpad/launchpad-sbx-metadata.xml"
+# saml_launchpad_metadata_url     = "s3 url to identity provider public metadata xml file, e.g. s3://system_bucket/PREFIX/launchpad/launchpad-sbx-metadata.xml"
 
 ## Optional
 # key_name = "MY-KEY"

--- a/cumulus-tf/variables.tf
+++ b/cumulus-tf/variables.tf
@@ -83,7 +83,7 @@ variable "saml_idp_login" {
   default = "N/A"
 }
 
-variable "saml_launchpad_metadata_path" {
+variable "saml_launchpad_metadata_url" {
   type    = string
   default = "N/A"
 }


### PR DESCRIPTION
per "Migration Steps" for [cumulus 1.18 release notes](https://github.com/nasa/cumulus/releases/tag/v1.18.0):

> # Migration Steps
> * Change variable `saml_launchpad_metadata_path` to `saml_launchpad_metadata_url` in the `cumulus` Terraform module.
