### PR TITLE
Template updates

### DIFF
--- a/cumulus-tf/additions.tf.example
+++ b/cumulus-tf/additions.tf.example
@@ -102,7 +102,7 @@ resource "aws_iam_role" "sample_role" {
 }
 
 module "hello_and_bye_world_workflow" {
-  source = "https://github.com/nasa/cumulus/releases/download/v1.19.0/terraform-aws-cumulus-workflow.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v1.20.0/terraform-aws-cumulus-workflow.zip"
 
   prefix                                = var.prefix
   name                                  = "HelloAndByeWorldWorkflow"

--- a/cumulus-tf/hello_world_workflow.tf
+++ b/cumulus-tf/hello_world_workflow.tf
@@ -1,5 +1,5 @@
 module "hello_world_workflow" {
-  source = "https://github.com/nasa/cumulus/releases/download/v1.19.0/terraform-aws-cumulus-workflow.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v1.20.0/terraform-aws-cumulus-workflow.zip"
 
   prefix                                = var.prefix
   name                                  = "HelloWorldWorkflow"

--- a/cumulus-tf/main.tf
+++ b/cumulus-tf/main.tf
@@ -15,6 +15,9 @@ module "cumulus" {
 
   prefix = var.prefix
 
+  # DO NOT CHANGE THIS VARIABLE UNLESS DEPLOYING OUTSIDE NGAP
+  deploy_to_ngap = true
+
   vpc_id            = var.vpc_id
   lambda_subnet_ids = var.subnet_ids
 

--- a/cumulus-tf/main.tf
+++ b/cumulus-tf/main.tf
@@ -1,3 +1,13 @@
+locals {
+  tags = {
+    Deployment = var.prefix
+  }
+  elasticsearch_alarms            = lookup(data.terraform_remote_state.data_persistence.outputs, "elasticsearch_alarms", [])
+  elasticsearch_domain_arn        = lookup(data.terraform_remote_state.data_persistence.outputs, "elasticsearch_domain_arn", null)
+  elasticsearch_hostname          = lookup(data.terraform_remote_state.data_persistence.outputs, "elasticsearch_hostname", null)
+  elasticsearch_security_group_id = lookup(data.terraform_remote_state.data_persistence.outputs, "elasticsearch_security_group_id", "")
+}
+
 module "cumulus" {
   source = "https://github.com/nasa/cumulus/releases/download/v1.19.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
@@ -59,10 +69,10 @@ module "cumulus" {
   system_bucket = var.system_bucket
   buckets       = var.buckets
 
-  elasticsearch_alarms            = data.terraform_remote_state.data_persistence.outputs.elasticsearch_alarms
-  elasticsearch_domain_arn        = data.terraform_remote_state.data_persistence.outputs.elasticsearch_domain_arn
-  elasticsearch_hostname          = data.terraform_remote_state.data_persistence.outputs.elasticsearch_hostname
-  elasticsearch_security_group_id = data.terraform_remote_state.data_persistence.outputs.elasticsearch_security_group_id
+  elasticsearch_alarms            = local.elasticsearch_alarms
+  elasticsearch_domain_arn        = local.elasticsearch_domain_arn
+  elasticsearch_hostname          = local.elasticsearch_hostname
+  elasticsearch_security_group_id = local.elasticsearch_security_group_id
 
   dynamo_tables = data.terraform_remote_state.data_persistence.outputs.dynamo_tables
 
@@ -82,12 +92,6 @@ module "cumulus" {
   deploy_distribution_s3_credentials_endpoint = var.deploy_distribution_s3_credentials_endpoint
 
   tags = local.tags
-}
-
-locals {
-  tags = {
-    Deployment = var.prefix
-  }
 }
 
 terraform {

--- a/cumulus-tf/main.tf
+++ b/cumulus-tf/main.tf
@@ -9,7 +9,7 @@ locals {
 }
 
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v1.19.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v1.20.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
   cumulus_message_adapter_lambda_layer_arn = var.cumulus_message_adapter_lambda_layer_arn
 

--- a/cumulus-tf/variables.tf
+++ b/cumulus-tf/variables.tf
@@ -266,5 +266,5 @@ variable "api_users" {
 variable "urs_url" {
   description = "The URL of the Earthdata login (URS) site"
   type        = string
-  default     = "https://uat.urs.earthdata.nasa.gov/"
+  default     = "https://uat.urs.earthdata.nasa.gov"
 }

--- a/data-persistence-tf/main.tf
+++ b/data-persistence-tf/main.tf
@@ -1,5 +1,5 @@
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v1.19.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v1.20.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                     = var.prefix
   subnet_ids                 = var.subnet_ids


### PR DESCRIPTION
Do not merge until next release after 1.19 which includes these PRs:

https://github.com/nasa/cumulus/pull/1515
https://github.com/nasa/cumulus/pull/1510

Includes:

- CUMULUS-1739: Handle optional ES deployment for Cumulus module
- CUMULUS-1769: Allow non-NGAP users to change resource policy for archive API gateway