### PR TITLE
Surface separate lambda and ecs cluster subnet lists

### DIFF
--- a/cumulus-tf/main.tf
+++ b/cumulus-tf/main.tf
@@ -19,10 +19,10 @@ module "cumulus" {
   deploy_to_ngap = true
 
   vpc_id            = var.vpc_id
-  lambda_subnet_ids = var.subnet_ids
+  lambda_subnet_ids = var.lambda_subnet_ids
 
   ecs_cluster_instance_image_id   = var.ecs_cluster_instance_image_id
-  ecs_cluster_instance_subnet_ids = var.subnet_ids
+  ecs_cluster_instance_subnet_ids = var.ecs_cluster_instance_subnet_ids
   ecs_cluster_min_size            = 1
   ecs_cluster_desired_size        = 1
   ecs_cluster_max_size            = 2
@@ -43,7 +43,7 @@ module "cumulus" {
   ems_username          = var.ems_username
 
 
-  metrics_es_host = var.metrics_es_host
+  metrics_es_host     = var.metrics_es_host
   metrics_es_password = var.metrics_es_password
   metrics_es_username = var.metrics_es_username
 
@@ -83,14 +83,14 @@ module "cumulus" {
 
   archive_api_users = var.api_users
 
-  distribution_url = var.distribution_url
+  distribution_url            = var.distribution_url
   thin_egress_jwt_secret_name = var.thin_egress_jwt_secret_name
 
-  archive_api_port            = var.archive_api_port
-  private_archive_api_gateway = var.private_archive_api_gateway
-  api_gateway_stage = var.api_gateway_stage
+  archive_api_port              = var.archive_api_port
+  private_archive_api_gateway   = var.private_archive_api_gateway
+  api_gateway_stage             = var.api_gateway_stage
   log_api_gateway_to_cloudwatch = var.log_api_gateway_to_cloudwatch
-  log_destination_arn = var.log_destination_arn
+  log_destination_arn           = var.log_destination_arn
 
   deploy_distribution_s3_credentials_endpoint = var.deploy_distribution_s3_credentials_endpoint
 

--- a/cumulus-tf/main.tf
+++ b/cumulus-tf/main.tf
@@ -21,12 +21,15 @@ module "cumulus" {
   vpc_id            = var.vpc_id
   lambda_subnet_ids = var.lambda_subnet_ids
 
-  ecs_cluster_instance_image_id   = var.ecs_cluster_instance_image_id
-  ecs_cluster_instance_subnet_ids = var.ecs_cluster_instance_subnet_ids
-  ecs_cluster_min_size            = 1
-  ecs_cluster_desired_size        = 1
-  ecs_cluster_max_size            = 2
-  key_name                        = var.key_name
+  ecs_cluster_instance_image_id = var.ecs_cluster_instance_image_id
+  ecs_cluster_instance_subnet_ids = (var.ecs_cluster_instance_subnet_ids == null
+    ? var.lambda_subnet_ids
+    : var.ecs_cluster_instance_subnet_ids
+  )
+  ecs_cluster_min_size     = 1
+  ecs_cluster_desired_size = 1
+  ecs_cluster_max_size     = 2
+  key_name                 = var.key_name
 
   urs_url             = var.urs_url
   urs_client_id       = var.urs_client_id

--- a/cumulus-tf/main.tf
+++ b/cumulus-tf/main.tf
@@ -22,7 +22,7 @@ module "cumulus" {
   lambda_subnet_ids = var.lambda_subnet_ids
 
   ecs_cluster_instance_image_id = var.ecs_cluster_instance_image_id
-  ecs_cluster_instance_subnet_ids = (var.ecs_cluster_instance_subnet_ids == null
+  ecs_cluster_instance_subnet_ids = (length(var.ecs_cluster_instance_subnet_ids) == 0
     ? var.lambda_subnet_ids
     : var.ecs_cluster_instance_subnet_ids
   )

--- a/cumulus-tf/terraform.tfvars.example
+++ b/cumulus-tf/terraform.tfvars.example
@@ -3,11 +3,11 @@ region = "us-east-1"
 # Replace 12345 with your actual AWS account ID
 cumulus_message_adapter_lambda_layer_arn = "arn:aws:lambda:us-east-1:12345:layer:Cumulus_Message_Adapter:4"
 permissions_boundary_arn                 = "arn:aws:iam::12345:policy/NGAPShRoleBoundary"
-
 ecs_cluster_instance_image_id            = "ami-12345abcde"
 
 # Replace all instances of PREFIX with your deployment prefix
 prefix  = "PREFIX"
+
 buckets = {
   internal = {
     name = "PREFIX-internal"
@@ -16,19 +16,21 @@ buckets = {
   private = {
     name = "PREFIX-private"
     type = "private"
-  },
+  }
   protected = {
     name = "PREFIX-protected"
     type = "protected"
-  },
+  }
   public = {
     name = "PREFIX-public"
     type = "public"
   }
 }
-subnet_ids    = ["subnet-12345"]
-system_bucket = "PREFIX-internal"
-vpc_id        = "vpc-12345"
+
+lambda_subnet_ids               = ["subnet-12345"]
+ecs_cluster_instance_subnet_ids = ["subnet-12345"]
+system_bucket                   = "PREFIX-internal"
+vpc_id                          = "vpc-12345"
 
 cmr_client_id   = "CHANGEME"
 cmr_environment = "UAT"

--- a/cumulus-tf/variables.tf
+++ b/cumulus-tf/variables.tf
@@ -31,7 +31,7 @@ variable "cmr_oauth_provider" {
 
 variable "ecs_cluster_instance_subnet_ids" {
   type    = list(string)
-  default = null
+  default = []
 }
 
 variable "lambda_subnet_ids" {

--- a/cumulus-tf/variables.tf
+++ b/cumulus-tf/variables.tf
@@ -30,7 +30,8 @@ variable "cmr_oauth_provider" {
 }
 
 variable "ecs_cluster_instance_subnet_ids" {
-  type = list(string)
+  type    = list(string)
+  default = null
 }
 
 variable "lambda_subnet_ids" {

--- a/cumulus-tf/variables.tf
+++ b/cumulus-tf/variables.tf
@@ -25,22 +25,31 @@ variable "cumulus_message_adapter_lambda_layer_arn" {
 }
 
 variable "cmr_oauth_provider" {
-  type = string
+  type    = string
   default = "earthdata"
 }
 
+variable "ecs_cluster_instance_subnet_ids" {
+  type = list(string)
+}
+
+variable "lambda_subnet_ids" {
+  type    = list(string)
+  default = []
+}
+
 variable "launchpad_api" {
-  type = string
+  type    = string
   default = "launchpadApi"
 }
 
 variable "launchpad_certificate" {
-  type = string
+  type    = string
   default = "launchpad.pfx"
 }
 
 variable "launchpad_passphrase" {
-  type = string
+  type    = string
   default = ""
 }
 
@@ -88,10 +97,6 @@ variable "saml_launchpad_metadata_url" {
   default = "N/A"
 }
 
-variable "subnet_ids" {
-  type = list(string)
-}
-
 variable "system_bucket" {
   type = string
 }
@@ -132,8 +137,8 @@ variable "buckets" {
 
 variable "deploy_distribution_s3_credentials_endpoint" {
   description = "Whether or not to include the S3 credentials endpoint in the Thin Egress App"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "distribution_url" {
@@ -179,7 +184,7 @@ variable "ems_private_key" {
 variable "ems_provider" {
   type        = string
   description = "the provider used for sending reports to EMS"
-  default = null
+  default     = null
 }
 
 variable "ems_retention_in_days" {
@@ -197,7 +202,7 @@ variable "ems_submit_report" {
 variable "ems_username" {
   type        = string
   description = "the username used for sending reports to EMS"
-  default = null
+  default     = null
 
 }
 
@@ -239,27 +244,27 @@ variable "archive_api_port" {
 }
 
 variable "private_archive_api_gateway" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "metrics_es_host" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "metrics_es_password" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "metrics_es_username" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "api_users" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 


### PR DESCRIPTION
Internally, the Cumulus Terraform module uses separate variables for
subnet IDs for Lambdas and subnet IDs for the ECS cluster, but this
example deployment was using only 1 list of subnet IDs for both
purposes.  One case where this can be limiting is when a user wants
`private_archive_api_gateway` is set to `false` and also specify an
empty list of subnet IDs for Lambdas while specifying at least one
subnet ID for the ECS cluster, which is required.