### PR TITLE
Update template to no longer use rds_connection_heartbeat

### DIFF
--- a/cumulus-tf/main.tf
+++ b/cumulus-tf/main.tf
@@ -67,7 +67,6 @@ module "cumulus" {
 
   rds_security_group         = local.rds_security_group
   rds_user_access_secret_arn = local.rds_credentials_secret_arn
-  rds_connection_heartbeat   = var.rds_connection_heartbeat
 
   urs_url             = var.urs_url
   urs_client_id       = var.urs_client_id

--- a/cumulus-tf/terraform.tfvars.example
+++ b/cumulus-tf/terraform.tfvars.example
@@ -5,8 +5,6 @@ region = "us-east-1"
 
 cumulus_message_adapter_version = "1.3.0"
 
-rds_connection_heartbeat = true
-
 # Replace 12345 with your actual AWS account ID
 permissions_boundary_arn                 = "arn:aws:iam::12345:policy/NGAPShRoleBoundary"
 

--- a/cumulus-tf/variables.tf
+++ b/cumulus-tf/variables.tf
@@ -29,13 +29,6 @@ variable "cmr_provider" {
 variable "cmr_username" {
   type = string
 }
-
-variable "rds_connection_heartbeat" {
-  description = "If true, send a query to verify database connection is live on connection creation and retry on initial connection timeout.  Set to false if not using serverless RDS"
-  type        = bool
-  default     = false
-}
-
 variable "cmr_oauth_provider" {
   type    = string
   default = "earthdata"

--- a/data-migration1-tf/main.tf
+++ b/data-migration1-tf/main.tf
@@ -34,7 +34,6 @@ module "data_migration1" {
 
   rds_security_group_id = data.terraform_remote_state.data_persistence.outputs.rds_security_group
   rds_user_access_secret_arn = data.terraform_remote_state.data_persistence.outputs.rds_user_access_secret_arn
-  rds_connection_heartbeat = var.rds_connection_heartbeat
 
   provider_kms_key_id = var.provider_kms_key_id
 

--- a/data-migration1-tf/variables.tf
+++ b/data-migration1-tf/variables.tf
@@ -22,12 +22,6 @@ variable "permissions_boundary_arn" {
   default = null
 }
 
-variable "rds_connection_heartbeat" {
-  description = "If true, send a query to verify database connection is live on connection creation and retry on initial connection timeout.  Set to false if not using serverless RDS"
-  type    = bool
-  default = true
-}
-
 variable "region" {
   type    = string
   default = "us-east-1"


### PR DESCRIPTION
This update removes the heartbeat flag that was removed from Core.  This should not be merged until the Core PR including
CUMULUS-2528 is released.