### PR TITLE
Updates Cumulus sources for release 18.2.2

### DIFF
--- a/cumulus-tf/additions.tf.example
+++ b/cumulus-tf/additions.tf.example
@@ -102,7 +102,7 @@ resource "aws_iam_role" "sample_role" {
 }
 
 module "hello_and_bye_world_workflow" {
-  source = "https://github.com/nasa/cumulus/releases/download/v15.0.2/terraform-aws-cumulus-workflow.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v18.2.2/terraform-aws-cumulus-workflow.zip"
 
   prefix                                = var.prefix
   name                                  = "HelloAndByeWorldWorkflow"

--- a/cumulus-tf/hello_world_workflow.tf
+++ b/cumulus-tf/hello_world_workflow.tf
@@ -1,5 +1,5 @@
 module "hello_world_workflow" {
-  source = "https://github.com/nasa/cumulus/releases/download/v17.0.0/terraform-aws-cumulus-workflow.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v18.2.2/terraform-aws-cumulus-workflow.zip"
 
   prefix          = var.prefix
   name            = "HelloWorldWorkflow"

--- a/cumulus-tf/main.tf
+++ b/cumulus-tf/main.tf
@@ -47,7 +47,7 @@ data "terraform_remote_state" "data_persistence" {
 
 
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v18.2.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v18.2.2/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
   cumulus_message_adapter_lambda_layer_version_arn = aws_lambda_layer_version.cma_layer.arn
 

--- a/data-persistence-tf/main.tf
+++ b/data-persistence-tf/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 data "aws_region" "current" {}
 
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v18.2.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v18.2.2/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                         = var.prefix
   subnet_ids                     = var.subnet_ids

--- a/rds-cluster-tf/main.tf
+++ b/rds-cluster-tf/main.tf
@@ -14,7 +14,7 @@ provider "aws" {
 data "aws_region" "current" {}
 
 module "rds_cluster" {
-  source = "https://github.com/nasa/cumulus/releases/download/v18.2.0/terraform-aws-cumulus-rds.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v18.2.2/terraform-aws-cumulus-rds.zip"
   db_admin_username        = var.db_admin_username
   db_admin_password        = var.db_admin_password
   region                   = var.region


### PR DESCRIPTION
As a result of releasing [Cumulus Core 18.2.2](https://github.com/nasa/cumulus/releases/tag/v18.2.2) (https://bugs.earthdata.nasa.gov/browse/CUMULUS-3726) I've updated the Cumulus sources to point to the new release.